### PR TITLE
rs232_test: fix memory leak

### DIFF
--- a/src/rs232_test.c
+++ b/src/rs232_test.c
@@ -58,8 +58,10 @@ unsigned int rs232_simple_test(void)
 	rs232_set_device(p, "/dev/ttyUSB0");
 #endif
 	ret = rs232_open(p);
-	if (ret)
+	if (ret) {
+		rs232_end(p);
 		return err(ret);
+	}
 
 	rs232_set_baud(p, RS232_BAUD_115200);
 	printf("[*] port settings: %s\n", rs232_to_string(p));


### PR DESCRIPTION
if rs232_init() return successfully then you must call rs232_end() before terminate program.
